### PR TITLE
Metabox para estatísticas na tela de edição de post

### DIFF
--- a/admin/class-post-useful-options.php
+++ b/admin/class-post-useful-options.php
@@ -1,1 +1,97 @@
 <?php
+
+class Post_Useful_Options {
+
+	/**
+	 * Holds the statistics metabox slug
+	 *
+	 * @var string
+	 */
+	protected $statistics_metabox_slug;
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var object
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Instance of the main class
+	 */
+	protected $post_useful_class = null;
+
+	protected $post_types_metabox;
+
+	protected $wpdb;
+
+	public function __construct() {
+		global $wpdb;
+		$this->wpdb = $wpdb;
+
+		$this->statistics_metabox_slug 	= Post_Useful::$plugin_slug . '-statistics_metabox';
+		$this->post_useful_class 		= Post_Useful::get_instance();
+
+
+		$this->post_types_metabox = apply_filters( 'post_useful_statistics_post_types', array('post') );
+		foreach($this->post_types_metabox as $post_type) {
+			add_action( 'add_meta_boxes_' . $post_type, array( $this, 'statistics_metabox' ) );
+		}
+
+		add_action('admin_enqueue_scripts', array($this, 'enqueue_scripts') ); 
+		
+
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @return object A single instance of this class.
+	 */
+	public static function get_instance() {
+		// If the single instance hasn't been set, set it now.
+		if ( null == self::$instance ) {
+			self::$instance = new self;
+		}
+		return self::$instance;
+	}
+
+
+	/**
+	 * Load scripts js and styles css for admin
+	 */
+	public function enqueue_scripts() {
+		$screen = get_current_screen();
+
+		//Load style.css for metabox
+		if ( in_array($screen->id, $this->post_types_metabox) ) {
+			wp_enqueue_style( 'post_useful_css_main', plugins_url( '../assets/css/main.css', __FILE__ ), array(), null, 'all' );
+		}
+		
+	}
+
+	public function statistics_metabox() {
+		add_meta_box(
+			$this->statistics_metabox_slug,
+			__('Post Useful Statistics', 'post_useful'),
+			array( $this, 'statistics_metabox_display'),
+			null,
+			'side',
+			'default'
+		);
+	}
+
+	public function statistics_metabox_display() {
+		$vote_yes = $this->wpdb->get_var( $this->wpdb->prepare('SELECT rating FROM ' . $this->post_useful_class->table .' WHERE post_id = %d', 
+							  array(get_the_ID() ) ) );
+
+		$vote_no  = 0;
+
+		$metabox = '<div class="post-useful-buttons post-useful-metabox">';
+			$metabox .= '<span class="post-useful-vote post-useful-vote-yes">' . $vote_yes . '</span>';
+			$metabox .= '<span class="post-useful-vote post-useful-vote-no">'  . $vote_no  . '</span>';
+		$metabox .= '</div>';
+
+		echo $metabox;
+	}
+}

--- a/admin/class-post-useful-options.php
+++ b/admin/class-post-useful-options.php
@@ -18,12 +18,25 @@ class Post_Useful_Options {
 
 	/**
 	 * Instance of the main class
+	 * 
+	 * @var object
 	 */
 	protected $post_useful_class = null;
 
+
+	/**
+	 * Posts types where we need to show statistics metabox
+	 * 
+	 * @var array
+	 */
 	protected $post_types_metabox;
 
-	protected $wpdb;
+	/**
+	 * Global $wpdb
+	 * 
+	 * @var object
+	 */
+	private $wpdb;
 
 	public function __construct() {
 		global $wpdb;
@@ -70,6 +83,9 @@ class Post_Useful_Options {
 		
 	}
 
+	/**
+	 * Add a meta box to a post edit screen
+	 */
 	public function statistics_metabox() {
 		add_meta_box(
 			$this->statistics_metabox_slug,
@@ -81,11 +97,20 @@ class Post_Useful_Options {
 		);
 	}
 
-	public function statistics_metabox_display() {
-		$vote_yes = $this->wpdb->get_var( $this->wpdb->prepare('SELECT rating FROM ' . $this->post_useful_class->table .' WHERE post_id = %d', 
-							  array(get_the_ID() ) ) );
 
-		$vote_no  = 0;
+	/**
+	 * Display the contento of the statistics metabox
+	 */
+	public function statistics_metabox_display() {
+		$vote_yes = $this->wpdb->get_var( 
+								$this->wpdb->prepare('SELECT COUNT(*) FROM ' . $this->post_useful_class->table .' WHERE post_id = %d AND rating = %d', 
+							  	array(get_the_ID(), 1) ) 
+							);
+
+		$vote_no = $this->wpdb->get_var( 
+								$this->wpdb->prepare('SELECT COUNT(*) FROM ' . $this->post_useful_class->table .' WHERE post_id = %d AND rating = %d', 
+							  	array(get_the_ID(), 0) ) 
+							);
 
 		$metabox = '<div class="post-useful-buttons post-useful-metabox">';
 			$metabox .= '<span class="post-useful-vote post-useful-vote-yes">' . $vote_yes . '</span>';

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -30,12 +30,11 @@
 			border:0;
 		}
 			.post-useful-vote-yes{
-				background:url("../images/yes_hover.png") no-repeat;
-				background-position: 0 0;
+				background-image:url("../images/yes_hover.png");
 			}
 				.post-useful-vote-yes:hover{ background-position: 0 32px; }
 			.post-useful-vote-no{
-				background:url("../images/no_hover.png") no-repeat;
+				background-image:url("../images/no_hover.png");
 				margin-left:10px;
 			}
 				.post-useful-vote-no:hover{ background-position: 0 32px; }
@@ -49,7 +48,7 @@
 	width: 55px;
 	padding-left: 35px;
 	line-height: 32px;
-	
+	background-repeat: no-repeat;
 	text-indent: 0;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -30,13 +30,35 @@
 			border:0;
 		}
 			.post-useful-vote-yes{
-				background-image:url("../images/yes_hover.png");
+				background:url("../images/yes_hover.png") no-repeat;
 				background-position: 0 0;
 			}
 				.post-useful-vote-yes:hover{ background-position: 0 32px; }
 			.post-useful-vote-no{
-				background-image:url("../images/no_hover.png");
+				background:url("../images/no_hover.png") no-repeat;
 				margin-left:10px;
 			}
 				.post-useful-vote-no:hover{ background-position: 0 32px; }
 			.post_useful_active{ background-position: 0 32px; }
+
+/* Admin Styles */
+.post-useful-metabox {
+	float:none !important;
+}
+.post-useful-metabox .post-useful-vote {
+	width: 55px;
+	padding-left: 35px;
+	line-height: 32px;
+	
+	text-indent: 0;
+}
+
+.post-useful-metabox .post-useful-vote-no {
+	position: relative;
+	top: 1px;
+}
+
+.post-useful-metabox > .post-useful-vote-yes:hover,
+.post-useful-metabox > .post-useful-vote-no:hover {
+	background-position: 0 0 !important;
+}

--- a/post-useful.php
+++ b/post-useful.php
@@ -20,6 +20,12 @@
 	class Post_Useful {
 
 		/**
+		 * Pluglin Slug
+		 * @var strng
+		 */
+		public static $plugin_slug = 'post_useful';
+
+		/**
 		 * Global $wpdb
 		 * 
 		 * @var object
@@ -43,7 +49,7 @@
 		 * 
 		 * @var string
 		 */
-		private $table = '';
+		public $table = '';
 
 		/**
 		 * Initialize the plugin
@@ -116,13 +122,6 @@
 			dbDelta( $sql );
 
 			update_option('post_useful_db_version', self::$post_useful_db_version);
-		}
-
-		/**
-		 * Require classes admin
-		 */
-		protected function require_admin() {
-			require_once 'admin/class-post-useful-options.php';
 		}
 
 		/**
@@ -209,8 +208,15 @@
 			wp_die();
 		}
 	}
+
 	register_activation_hook( __FILE__ , array( 'Post_Useful', 'activate') );
 	add_action( 'plugins_loaded', array( 'Post_Useful', 'get_instance' ), 0 );
+
+	if ( is_admin() ) {
+		require_once( plugin_dir_path( __FILE__ ) . 'admin/class-post-useful-options.php' );
+		add_action('after_setup_theme', array('Post_Useful_Options', 'get_instance') );
+	}
+
 
 
 

--- a/post-useful.php
+++ b/post-useful.php
@@ -70,6 +70,7 @@
 
 			// Ajax send rate
 			add_action( 'wp_ajax_send_rate', array( $this, 'send_rate' ) );
+			add_action( 'wp_ajax_nopriv_send_rate', array( $this, 'send_rate' ) );
 		}
 
 		/**


### PR DESCRIPTION
Fiz um esboço para o metabox que exibe as estatísticas, basicamente usei os ícones para mostrar os votos que acharam útil e inúteis, não sei se a ideia era essa, mas tá aí, ainda dá pra melhorar!

Coloquei um filtro para o usuário poder escolher onde exibir as estatísticas:

``` php
$this->post_types_metabox = apply_filters( 'post_useful_statistics_post_types', array('post') );
```

Depois que fizer a tela de configuração podemos usar as configurações para sobrescrever os filtros ou ao contrário.
